### PR TITLE
New Update.do "expo start"  error" yarn opções "

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Você pode visualizar o layout do projeto através [desse link](https://www.figm
 - Clone o repositório
 - Instale as dependências com `yarn`
 - Inicie seu app com `expo start`
+- Para fazer um novo uso de projeto expo init [path]
+- yarn start # you can open iOS, Android, or web from here, or run them directly with the commands below.
+- yarn android
+- yarn ios # requires an iOS device or macOS for access to an iOS simulator
+- yarn web
 - Inicie a fake api com `json-server ./src/services server.json --host 192.168.1.4 --port 3333 --delay 700`. Substitua o host pelo seu endereço IP local. Faça o mesmo no arquivo API dentro de services.
 
 ## 📄 Licença


### PR DESCRIPTION
Your project is ready!

To run your project, navigate to the directory and run one of the following yarn commands.



yarn start # you can open iOS, Android, or web from here, or run them directly with the commands below.
- yarn android
- yarn ios # requires an iOS device or macOS for access to an iOS simulator


- yarn web

yarn web
yarn run v1.22.10
$ expo start --web
Starting project at C:\Users\cleverTon\nlww\plantmanager
Developer tools running on http://localhost:.......____
Opening developer tools in the browser...
Starting Metro Bundler
Starting Webpack on port in ..........development mode.